### PR TITLE
Automatically choose next validator from propose queue

### DIFF
--- a/src/web/controls/custom-deploy-ctrl.js
+++ b/src/web/controls/custom-deploy-ctrl.js
@@ -90,7 +90,7 @@ export const customDeployCtrl = (st, {wallet = [], node, onSendDeploy, onPropose
   }
 
   // Control state
-  const {selRevAddr, code, phloLimit, status, dataError, proposeStatus, proposeError}
+  const {selRevAddr, code, phloLimit, status, dataError, proposeStatus, proposeError, fetching}
     = initSelected(st.view({}), wallet)
 
   const tokenName        = node.tokenName
@@ -99,7 +99,7 @@ export const customDeployCtrl = (st, {wallet = [], node, onSendDeploy, onPropose
   const labelPhloLimit   = `Phlo limit (in tiny ${tokenName} x10^${node.tokenDecimal})`
   const isWalletEmpty    = R.isNil(wallet) || R.isEmpty(wallet)
   const showPropose      = node.network === 'localnet'
-  const canDeploy        = (code || '').trim() !== '' && !!selRevAddr
+  const canDeploy        = (code || '').trim() !== '' && !!selRevAddr  && !fetching
   const phloLimitPreview = showTokenDecimal(phloLimit, node.tokenDecimal)
 
   return m('.ctrl.custom-deploy-ctrl',

--- a/src/web/controls/selector-ctrl.js
+++ b/src/web/controls/selector-ctrl.js
@@ -3,7 +3,7 @@ import * as R from 'ramda'
 import m from 'mithril'
 import { getNodeUrls } from '../../rchain-networks'
 
-export const selectorCtrl = (st, {nets, onDevMode}) => {
+export const selectorCtrl = (st, {nets, onDevMode, onAutoSelectToggle}) => {
   const findValidatorByIndex = index =>
     nets.flatMap(({hosts}) => hosts)[index]
 
@@ -13,6 +13,8 @@ export const selectorCtrl = (st, {nets, onDevMode}) => {
   const onSelIdx = ev => {
     const sel  = findValidatorByIndex(ev.target.selectedIndex)
     const read = sel.name === valNode.name ? readNode : findReadOnlyByIndex(0, sel.name)
+    const isMainnet = sel.name === 'mainnet'
+    sel.name !== valNode.name ? onAutoSelectToggle({disabled: !isMainnet}) : undefined
     st.set({valNode: sel, readNode: read})
   }
 
@@ -26,6 +28,11 @@ export const selectorCtrl = (st, {nets, onDevMode}) => {
     onDevMode({enabled: checked})
   }
 
+  const onAutoSelectInput = ev => {
+    const checked = ev.target?.checked || false
+    onAutoSelectToggle({disabled: checked})
+  }
+
   const getDdlText = ({name, domain, grpc, https, http}) => {
     const httpInfo = !!https ? `:${https}` : !!http ? `:${http}` : ' '
     const isLocal  = name === 'localnet'
@@ -36,7 +43,7 @@ export const selectorCtrl = (st, {nets, onDevMode}) => {
     R.eqBy(({domain, gprc, https, http}) => ({domain, gprc, https, http}), v1, v2)
 
   // Control state
-  const {valNode, readNode, devMode} = st.view({})
+  const {valNode, readNode, devMode, autoSelectDisabled} = st.view({})
 
   const isLocal   = valNode.name === 'localnet'
   const isTestnet = valNode.name === 'testnet'
@@ -45,6 +52,7 @@ export const selectorCtrl = (st, {nets, onDevMode}) => {
   const readUrls  = getNodeUrls(readNode)
   // Dev mode tooltip text
   const devModeText = `Development mode for locally accessible nodes`
+  const autoSelectText = `Disable automatic selection of validator`
 
   return m('.ctrl.selector-ctrl',
     // Validator selector
@@ -65,6 +73,11 @@ export const selectorCtrl = (st, {nets, onDevMode}) => {
         ),
       ),
     ),
+
+    isMainnet && [
+      m('label', {title: autoSelectText},
+      m('input[type=checkbox]', {checked: autoSelectDisabled, oninput: onAutoSelectInput}), 'Disable Auto Select')
+    ],
 
     // Validator info
     m(''),

--- a/src/web/controls/transfer-ctrl.js
+++ b/src/web/controls/transfer-ctrl.js
@@ -47,14 +47,14 @@ export const transferCtrl = (st, {wallet, node, onTransfer, warn}) => {
   }
 
   // Control state
-  const {account, toAccount, amount, status, error} = initSelected(st.view({}), wallet)
+  const {account, toAccount, amount, status, error, fetching} = initSelected(st.view({}), wallet)
 
   const {tokenName, tokenDecimal} = node
   const labelSource      = `Source ${tokenName} address`
   const labelDestination = `Destination ${tokenName} address`
   const labelAmount      = `Amount (in tiny ${tokenName} x10^${tokenDecimal})`
   const isWalletEmpty    = R.isNil(wallet) || R.isEmpty(wallet)
-  const canTransfer      = account && toAccount && amount && (account || ethDetected)
+  const canTransfer      = account && toAccount && amount && (account || ethDetected) && !fetching
   const amountPreview    = showTokenDecimal(amount, tokenDecimal)
 
   return m('.ctrl.transfer-ctrl',


### PR DESCRIPTION
This PR makes it so that deploys get into a block faster (within 1 minutes rather than 15 minutes) by automatically choosing one of the next two validators from the propose queue by using this API https://status.rchain.coop/api/validators. Finalization still takes quite a bit of time so improvement may not be significant.
All that is required from the user is to switch to mainnet. Switching back to any other network pauses the autoselector.
When mainnet is enabled, Transfer and Deploy buttons are disabled during the first fetch, so that user doesn't use a manually selected node.
For convenience there is a checkbox to manually disable this behavior too.


